### PR TITLE
Fix URL used for Hangouts in initChat 

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -1583,7 +1583,7 @@ void Client::pvtReply()
 
 void Client::initChat(QString pvt)
 {
-    QString surl = QString("https://talkgadget.google.com/u/0/talkgadget/_/chat?prop=hangish&fid=gtn-roster-iframe-id&ec=[\"ci:ec\",true,true,false]");
+    QString surl = QString("https://hangouts.google.com/webchat/u/0/load?prop=hangish&fid=gtn-roster-iframe-id&ec=[\"ci:ec\",true,true,false]");
     surl += "&pvt=";
     surl += pvt;
     QUrl url(surl);


### PR DESCRIPTION
As it seems the previous URL is not available any more.

Fixing this will make client usable again on Sailfish.